### PR TITLE
haskell-ci: Pass `--semaphore` to `cabal configure`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -45,8 +45,9 @@ on:
         description: Flags to pass to `cabal configure`, e.g., `--ghc-options='-Werror=default -j'`
         type: string
         required: false
-        # For an explanation of `--ghc-options='-j'`, see Note [Parallelism].
-        default: --ghc-options='-j' --enable-tests --minimize-conflict-set
+        # For an explanation of `--ghc-options='-j'` and `--semaphore`, see
+        # Note [Parallelism].
+        default: --ghc-options='-j' --semaphore --enable-tests --minimize-conflict-set
       fetch-depth:
         description: Number of commits to fetch. Passed to `actions/checkout`.
         type: number
@@ -241,10 +242,12 @@ jobs:
     #   `configure` step) to build local packages' modules in parallel.
     #
     # This scheme maximizes the use of parallelism while avoiding
-    # oversubscription. See GHC proposal #540 for additional background. It would
-    # be nice to replace this with `cabal configure --semaphore`, but this only
-    # became available with GHC 9.8. To support older versions, we don't use it
-    # just yet.
+    # oversubscription. See GHC proposal #540 for additional background.
+    #
+    # We also pass `--semaphore` to `cabal configure`. This is only supported
+    # on GHC >= 9.8, but Cabal simply ignores it for older compiler versions. If
+    # we ever only support GHC >= 9.8, we could combine the two steps and just
+    # pass `--semaphore`.
     - name: Build dependencies
       # If we had an exact cache hit, the dependencies will be up to date. This
       # step can take a few seconds even when it is a no-op, so skip it in that

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -264,7 +264,7 @@ jobs:
       #   cache miss, it will be set to false.
       #
       # However, this appears not to be true in practice, see #31.
-      if: steps.store-cache.outputs.cache-hit != 'true' || steps.store-cache.outputs.cache-primary-key != steps.store-cache.outputs.cache-matched
+      if: steps.store-cache.outputs.cache-hit != 'true' || steps.store-cache.outputs.cache-primary-key != steps.store-cache.outputs.cache-matched-key
       run: cabal build --only-dependencies -- ${{ inputs.build-targets }} ${{ inputs.test-targets }}
       working-directory: ${{ env.WORK_DIR }}
     - name: Save Cabal store cache


### PR DESCRIPTION
Fixes #21. This bumps our minimum supported Cabal version to 3.10 (which came out with GHC 9.8), but as described in the README, we only really aim to support the most recent version of Cabal.

p-u build: https://github.com/GaloisInc/parameterized-utils/actions/runs/14522456294/job/40746365622

You can see it in action on the 9.10 build:
```
Created semaphore called cabal_semaphore_2 with 4 slots.
```
And getting ignored on 8.6.5:
```
Warning: -jsem is not supported by the selected compiler, falling back to
normal parallelism control.
```