### PR TITLE
haskell-ci: Don't use `md5sum`

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -186,10 +186,9 @@ jobs:
       if: inputs.check-freeze
       run: |
         if [[ -f cabal.project.freeze ]]; then
-          old=$(md5sum cabal.project.freeze)
+          old=$(<cabal.project.freeze)
           cabal freeze
-          new=$(md5sum cabal.project.freeze)
-          [[ "${new}" == "${old}" ]]
+          echo "${old}" | diff -u - cabal.project.freeze
         fi
     - name: Create sdist
       run: |


### PR DESCRIPTION
It isn't always available on macOS runners.

Fixes #55.