### PR TITLE
haskell-ci: Report coverage information

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -379,7 +379,19 @@ jobs:
           exit 1
         fi
 
-        hpc report ${tix} ${hpc_args} ${HPC_FLAGS}
+        # This part will produce a Github-flavored Markdown report on the
+        # "job summary" page. The report will first contain the output of
+        # `hpc report` in a code block, followed by a collapsible "spoiler"
+        # containing the more detailed per-module information.
+        printf '## HPC coverage results\n' >> "${GITHUB_STEP_SUMMARY}"
+        printf '```\n' >> "${GITHUB_STEP_SUMMARY}"
+        hpc report ${tix} ${hpc_args} ${HPC_FLAGS} | tee -a "${GITHUB_STEP_SUMMARY}"
+        printf '```\n' >> "${GITHUB_STEP_SUMMARY}"
+        printf '<details><summary>Module-level summary</summary>\n\n' >> "${GITHUB_STEP_SUMMARY}"
+        printf '```\n' >> "${GITHUB_STEP_SUMMARY}"
+        hpc report ${tix} ${hpc_args} ${HPC_FLAGS} --per-module --decl-list | tee -a "${GITHUB_STEP_SUMMARY}"
+        printf '```\n\n' >> "${GITHUB_STEP_SUMMARY}"
+        printf '</details>\n' >> "${GITHUB_STEP_SUMMARY}"
     # Debloat dist-newstyle before caching it
     - name: Remove tix files from Cabal build directory
       working-directory: ${{ env.WORK_DIR }}

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -80,12 +80,12 @@ on:
           by adding `--enable-coverage` to the `configure-flags` input.
         type: boolean
         required: false
-        default: true
+        default: false
       coverage-artifact:
         description: Whether to produce an artifact containing an HTML coverage report
         type: boolean
         required: false
-        default: true
+        default: false
       fetch-depth:
         description: Number of commits to fetch. Passed to `actions/checkout`.
         type: number
@@ -102,7 +102,7 @@ on:
         required: false
         default: true
       hpc-flags:
-        description: Flags to pass to `hpc report`
+        description: Flags to pass to `hpc`
         type: string
         required: false
         default: ""
@@ -394,7 +394,7 @@ jobs:
           exit 1
         fi
 
-        # This part will produce a Github-flavored Markdown report on the
+        # This part will produce a GitHub-flavored Markdown report on the
         # "job summary" page. The report will first contain the output of
         # `hpc report` in a code block, followed by a collapsible "spoiler"
         # containing the more detailed per-module information.

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -73,7 +73,11 @@ on:
         # Note [Parallelism].
         default: --ghc-options='-j' --semaphore --enable-tests --minimize-conflict-set
       coverage:
-        description: Whether to run `hpc report` to report test-suite coverage.
+        description: |
+          Whether to run `hpc report` to report test-suite coverage.
+
+          Note that the client must enable some form of coverage tracking, e.g.,
+          by adding `--enable-coverage` to the `configure-flags` input.
         type: boolean
         required: false
         default: true

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -72,6 +72,11 @@ on:
         # For an explanation of `--ghc-options='-j'` and `--semaphore`, see
         # Note [Parallelism].
         default: --ghc-options='-j' --semaphore --enable-tests --minimize-conflict-set
+      coverage:
+        description: Whether to run `hpc report` to report test-suite coverage.
+        type: boolean
+        required: false
+        default: true
       fetch-depth:
         description: Number of commits to fetch. Passed to `actions/checkout`.
         type: number
@@ -87,6 +92,11 @@ on:
         type: boolean
         required: false
         default: true
+      hpc-flags:
+        description: Flags to pass to `hpc report`
+        type: string
+        required: false
+        default: ""
       os:
         description: |
           Runner OS, e.g., "ubuntu-latest".
@@ -333,6 +343,47 @@ jobs:
       run: cabal haddock --disable-documentation -- ${{ inputs.build-targets }}
       if: inputs.haddock
       working-directory: ${{ env.WORK_DIR }}
+    - name: Report test coverage
+      if: inputs.coverage
+      working-directory: ${{ env.WORK_DIR }}
+      # This step isn't essential, and it turns out that getting a coverage
+      # report is pretty non-trivial. Doing so properly involves a lot of
+      # shenanigans with paths inside dist-newstyle/, see e.g., saw-script's
+      # `compute-coverage.sh`. This step is currently best-effort, and may fail
+      # in corner cases (e.g., when versions are bumped, see saw-script#2114).
+      # Rather than anticipate and handle all the edge cases, we simply allow
+      # this to fail.
+      continue-on-error: true
+      env:
+        HPC_FLAGS: ${{ inputs.hpc-flags }}
+      run: |
+        # There can be multiple .tix files if the test suite runs an
+        # instrumented executable multiple times (e.g., for end-to-end tests).
+        # Combine all of the .tix files in the repo.
+        tixes=$(find . -name '*.tix' -print)
+        if [[ -z "${tixes}" ]]; then
+          exit 0
+        fi
+        tix="all.tix"
+        hpc sum --union --output=${tix} ${tixes}
+
+        # Find all `--hpcdir`s. Passing extras doesn't seem to matter, so just
+        # grab all of them.
+        hpc_args=""
+        for d in $(find dist-newstyle/ -path '*/hpc/vanilla/mix' -type d -print); do
+          hpc_args="${hpc_args} --hpcdir=${d}"
+        done
+
+        if [[ -z "${hpc_args}" ]]; then
+          echo 'Could not find `--hpcdir`s' 1>&2
+          exit 1
+        fi
+
+        hpc report ${tix} ${hpc_args} ${HPC_FLAGS}
+    # Debloat dist-newstyle before caching it
+    - name: Remove tix files from Cabal build directory
+      working-directory: ${{ env.WORK_DIR }}
+      run: find "${PROJECT_ROOT}/dist-newstyle" -type f -name '*.tix' -delete
     # Delete the old cache on hit to emulate a cache "update". See
     # https://github.com/actions/cache/issues/109 and
     # https://github.com/actions/cache/issues/342.

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -167,6 +167,10 @@ on:
         type: string
         required: false
         default: all
+    outputs:
+      coverage-artifact-id:
+        description: The ID of the coverage report artifact.
+        value: ${{ jobs.CI.outputs.coverage-artifact-id }}
 
 # General commentary
 # ------------------
@@ -181,6 +185,8 @@ on:
 jobs:
   CI:
     runs-on: ${{ inputs.os }}
+    outputs:
+      coverage-artifact-id: ${{ steps.coverage-artifact.outputs.artifact-id }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -400,6 +406,7 @@ jobs:
 
         hpc markup ${tix} ${hpc_args} ${HPC_FLAGS} --destdir=coverage-report
     - name: Create coverage report artifact
+      id: coverage-artifact
       if: inputs.coverage-artifact
       working-directory: ${{ env.WORK_DIR }}
       uses: actions/upload-artifact@v4

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -77,6 +77,11 @@ on:
         type: boolean
         required: false
         default: true
+      coverage-artifact:
+        description: Whether to produce an artifact containing an HTML coverage report
+        type: boolean
+        required: false
+        default: true
       fetch-depth:
         description: Number of commits to fetch. Passed to `actions/checkout`.
         type: number
@@ -392,6 +397,15 @@ jobs:
         hpc report ${tix} ${hpc_args} ${HPC_FLAGS} --per-module --decl-list | tee -a "${GITHUB_STEP_SUMMARY}"
         printf '```\n\n' >> "${GITHUB_STEP_SUMMARY}"
         printf '</details>\n' >> "${GITHUB_STEP_SUMMARY}"
+
+        hpc markup ${tix} ${hpc_args} ${HPC_FLAGS} --destdir=coverage-report
+    - name: Create coverage report artifact
+      if: inputs.coverage-artifact
+      working-directory: ${{ env.WORK_DIR }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report-${{ inputs.cache-key-prefix }}-${{ inputs.os }}-cabal${{ steps.setup-haskell.outputs.cabal-version }}-ghc${{ steps.setup-haskell.outputs.ghc-version }}
+        path: coverage-report/
     # Debloat dist-newstyle before caching it
     - name: Remove tix files from Cabal build directory
       working-directory: ${{ env.WORK_DIR }}

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -408,11 +408,10 @@ jobs:
     - name: Create coverage report artifact
       id: coverage-artifact
       if: inputs.coverage-artifact
-      working-directory: ${{ env.WORK_DIR }}
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report-${{ inputs.cache-key-prefix }}-${{ inputs.os }}-cabal${{ steps.setup-haskell.outputs.cabal-version }}-ghc${{ steps.setup-haskell.outputs.ghc-version }}
-        path: coverage-report/
+        path: ${{ env.WORK_DIR }}/coverage-report/
     # Debloat dist-newstyle before caching it
     - name: Remove tix files from Cabal build directory
       working-directory: ${{ env.WORK_DIR }}

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -360,7 +360,7 @@ jobs:
         # There can be multiple .tix files if the test suite runs an
         # instrumented executable multiple times (e.g., for end-to-end tests).
         # Combine all of the .tix files in the repo.
-        tixes=$(find . -name '*.tix' -print)
+        tixes=$(find . "${PROJECT_ROOT}/dist-newstyle" -name '*.tix' -print)
         if [[ -z "${tixes}" ]]; then
           exit 0
         fi
@@ -370,7 +370,7 @@ jobs:
         # Find all `--hpcdir`s. Passing extras doesn't seem to matter, so just
         # grab all of them.
         hpc_args=""
-        for d in $(find dist-newstyle/ -path '*/hpc/vanilla/mix' -type d -print); do
+        for d in $(find "${PROJECT_ROOT}/dist-newstyle" -path '*/hpc/vanilla/mix' -type d -print); do
           hpc_args="${hpc_args} --hpcdir=${d}"
         done
 


### PR DESCRIPTION
Fixes #53. Due to issues noted on that ticket, this is currently "best-effort", and is allowed to fail.

- [x] Test on a single-package project (p-u)
- [x] Test on a multi-package project (semmc)
- [x] Integrate HTML reporting a la https://github.com/GaloisInc/grease/pull/355
- [x] Upload the HTML coverage report as an artifact